### PR TITLE
chore: Remove unused CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# default is tech team
-* @berty/tech


### PR DESCRIPTION
The CODEOWNERS file is used to automatically assign reviewers when the pull request is created, including groups of people. There are many pull requests which still have these reviewers assigned who are not reviewing. This doesn't make sense. It is better to communicate with a specific dev who agrees to review. Therefore we remove the CODEOWNERS file.