### PR TITLE
Keeping yarn.lock to avoid breaking the build

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -15,3 +15,7 @@ __tests__
 
 # Exclude frameworks
 /ios/Frameworks
+
+# Excluding yarn.lock causes the local build to fail.
+# This is because the build is done on the host machine.
+!yarn.lock

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weshnet/expo",
-  "version": "0.0.9",
+  "version": "0.0.2",
   "description": "Weshnet React Native Expo module",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weshnet/expo",
-  "version": "0.0.2",
+  "version": "0.0.9",
   "description": "Weshnet React Native Expo module",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
Excluding yarn.lock causes the local build to fail. This is because the build is done on the host machine.