### PR TITLE
fix: manually copy API files in build/api folder

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -20,3 +20,6 @@ __tests__
 # Excluding yarn.lock causes the local build to fail.
 # This is because the build is done on the host machine.
 !yarn.lock
+
+# Go compilation needs .tool-versions
+!.tool-versions

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "clean": "expo-module clean",
     "lint": "expo-module lint",
     "test": "expo-module test",
-    "prepare": "expo-module prepare",
+    "prepare": "expo-module prepare && sh prepare.sh",
     "prepublishOnly": "expo-module prepublishOnly",
     "expo-module": "expo-module",
     "open:ios": "open -a \"Xcode\" example/ios",

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+#If the folder exists, copy API files
+if [ -d "./build" ]; then
+
+    cp ./src/api/protocoltypes.pb.js ./build/api/
+    cp ./src/api/protocoltypes.pb.d.ts ./build/api/
+    cp ./src/api/rpcmanager.pb.d.ts ./build/api/
+    cp ./src/api/rpcmanager.pb.js ./build/api/
+
+#Else prints an error
+else
+    echo "Error: build folder not found, please do \`yarn install\` first"
+fi


### PR DESCRIPTION
Doing `yarn` or `yarn install` creates a `build` directory with compiled files, but omits to include `src/api/rpcmanager.pb.d.ts`, `src/api/rpcmanager.pb.js`, `src/api/protocoltypes.pb.d.ts` and `src/api/protocoltypes.pb.js` into `build/api`.
So when a third app installs weshnet-expo as a dependency, `build/api/index.js` can't find those files and returns an error.

This PR add a new package.json script to copy those files into the `build/api` folder`. This script is added in the Makefile and in the Github Action release workflow.