### PR TITLE
fix: yarn.lock is missing when compiling the package as a dependency

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -17,9 +17,5 @@ __tests__
 /ios/Frameworks
 /android/libs
 
-# Excluding yarn.lock causes the local build to fail.
-# This is because the build is done on the host machine.
-!yarn.lock
-
 # Go compilation needs .tool-versions
 !.tool-versions

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ fclean: clean
 
 # - Node: Handle node_modules
 
-node_modules: package.json yarn.lock
+node_modules: package.json
 	(yarn && touch $@) || true
 
 # - API : Handle API generation and cleaning


### PR DESCRIPTION
fixes https://github.com/berty/weshnet-expo/issues/23

Like `package-lock.json`, `yarn.lock` will be ignore if not present to the root folder:
`One key detail about package-lock.json is that it cannot be published, and it will be ignored if found in any place other than the toplevel package.`
https://docs.npmjs.com/cli/v6/configuring-npm/package-lock-json

So just make it optional from the Makefile.